### PR TITLE
Add function for fetching all items under a heading

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,47 +1,45 @@
+const request = require("request");
 
-const request = require('request')
-
-const Lingo = function () { }
+const Lingo = function() {};
 
 class LingoError extends Error {
-    constructor(json) {
-        super(json.message || 'An unexpected error occured')
-        this.code = json.code || 1
-    }
+  constructor(json) {
+    super(json.message || "An unexpected error occured");
+    this.code = json.code || 1;
+  }
 }
 function parseJSONResponse(body) {
-    if (body.success === true) {
-        return body.result
-    } else if (body.success === false) {
-        throw new LingoError(body.error)
-    } else {
-        console.log("Response is missing success flag " + body)
-        throw new LingoError({
-            code: 1,
-            message: 'Unexpected server response'
-        })
-    }
+  if (body.success === true) {
+    return body.result;
+  } else if (body.success === false) {
+    throw new LingoError(body.error);
+  } else {
+    console.log("Response is missing success flag " + body);
+    throw new LingoError({
+      code: 1,
+      message: "Unexpected server response"
+    });
+  }
 }
-
 
 /**
  * Set your API auth credientials before using making any calls
  * @param {integer} spaceID The id of your Lingo space
  * @param {string} token An API token for your space
  */
-Lingo.prototype.setup = function (spaceID, token) {
-    this.auth = "Basic " + new Buffer(spaceID + ":" + token).toString("base64")
-}
+Lingo.prototype.setup = function(spaceID, token) {
+  this.auth = "Basic " + new Buffer(spaceID + ":" + token).toString("base64");
+};
 
 /**
  * Fetch all kits in your space
  * @returns {Promise} Success returns a list of kit objects
  */
-Lingo.prototype.fetchKits = function () {
-    return this.call('GET', '/kits').then(res => {
-        return res.kits
-    })
-}
+Lingo.prototype.fetchKits = function() {
+  return this.call("GET", "/kits").then(res => {
+    return res.kits;
+  });
+};
 
 /**
  * Fetch a single kit and it's versions
@@ -52,12 +50,12 @@ Lingo.prototype.fetchKits = function () {
  * - `null`: don't include any versions
  * @returns {Promise} Success returns a kit
  */
-Lingo.prototype.fetchKit = function (id, include = 'use_versions') {
-    let path = `/kits/${id}/?options=${include}`
-    return this.call('GET', path).then(res => {
-        return res.kit
-    })
-}
+Lingo.prototype.fetchKit = function(id, include = "use_versions") {
+  let path = `/kits/${id}/?options=${include}`;
+  return this.call("GET", path).then(res => {
+    return res.kit;
+  });
+};
 
 /**
  * Fetch the outline for a kit
@@ -65,12 +63,12 @@ Lingo.prototype.fetchKit = function (id, include = 'use_versions') {
  * @param {integer} version the version number of the kit to fetch
  * @returns {Promise} Success returns a list of sections and headers
  */
-Lingo.prototype.fetchKitOutline = function (id, version) {
-    let path = `/kits/${id}/outline?v=${version}`
-    return this.call('GET', path).then(res => {
-        return res.kit_version.sections
-    })
-}
+Lingo.prototype.fetchKitOutline = function(id, version) {
+  let path = `/kits/${id}/outline?v=${version}`;
+  return this.call("GET", path).then(res => {
+    return res.kit_version.sections;
+  });
+};
 
 /**
  * Fetch a section and optionally page through items with it
@@ -80,14 +78,69 @@ Lingo.prototype.fetchKitOutline = function (id, version) {
  * @param {integer} page the page of items
  * @returns {Promise} Success the section and the items matching the page/limit
  */
-Lingo.prototype.fetchSection = function (id, version, page = 1, limit = 50) {
-    let path = `/sections/${id}`
-    let v = version
-    let params = { qs: { v, page, limit } }
-    return this.call('GET', path, params).then(res => {
-        return res.section
-    })
-}
+Lingo.prototype.fetchSection = function(id, version, page = 1, limit = 50) {
+  let path = `/sections/${id}`;
+  let v = version;
+  let params = { qs: { v, page, limit } };
+  return this.call("GET", path, params).then(res => {
+    return res.section;
+  });
+};
+
+/**
+ * Fetch a section and optionally page through items with it
+ * @param {uuid} id the section uuid
+ * @param {integer} version the version number of the section to fetch
+ * @param {integer} limit The max number of items to fetch
+ * @param {integer} page the page of items
+ * @returns {Promise} Success the section and the items matching the page/limit
+ */
+Lingo.prototype.fetchAssetsForHeading = function(
+  sectionId,
+  headingId,
+  version
+) {
+  return new Promise((resolve, reject) => {
+    let page = 1;
+    let found = false;
+    const results = [];
+
+    function isMatch(item) {
+      return (
+        item.type == "heading" &&
+        (item.data.content == headingId || item.uuid == headingId)
+      );
+    }
+    const self = this;
+    function fetch() {
+      self
+        .fetchSection(sectionId, version, page)
+        .then(res => {
+          const items = res.items;
+          const count = items.length;
+          if (count == 0) {
+            return resolve(results);
+          }
+          for (var idx = 0; idx < count; idx++) {
+            const item = items[idx];
+            if (item.type == "heading" && found) {
+              return resolve(results);
+            } else if (isMatch(item)) {
+              found = true;
+            } else if (found) {
+              results.push(item);
+            }
+          }
+          page += 1;
+          fetch();
+        })
+        .catch(err => {
+          reject(err);
+        });
+    }
+    fetch();
+  });
+};
 
 /**
  * Search the items in a kit.
@@ -98,70 +151,74 @@ Lingo.prototype.fetchSection = function (id, version, page = 1, limit = 50) {
  * @param {integer} limit The max number of results per page
  * @returns {Promise} Returns the results, grouped by section.
  */
-Lingo.prototype.searchAssetsInKit = function (kitID, version, query, page, limit) {
-    const path = `/kits/${kitID}/search`
-    const v = version
-    let params = { qs: { v, query, page, limit } }
-    return this.call('GET', path, params)
-}
+Lingo.prototype.searchAssetsInKit = function(
+  kitID,
+  version,
+  query,
+  page,
+  limit
+) {
+  const path = `/kits/${kitID}/search`;
+  const v = version;
+  let params = { qs: { v, query, page, limit } };
+  return this.call("GET", path, params);
+};
 
-Lingo.prototype.downloadAsset = function (uuid, type = null) {
-    let path = `/assets/${uuid}/download`
-    const req = this._requestParams('GET', path, {
-        qs: { type },
-        json: false,
-        encoding: null
-    })
-    return new Promise(function (resolve, reject) {
-        request(req, function (err, response, body) {
-            if (body) {
-                contentType = response.caseless.get('Content-Type')
-                if (contentType.indexOf('json') >= 0) {
-                    try {
-                        resolve(parseJSONResponse(body))
-                    } catch (err) {
-                        reject(err)
-                    }
-                } else {
-                    resolve(body)
-                }
-            } else {
-                reject(err)
-            }
-        })
-    })
-}
+Lingo.prototype.downloadAsset = function(uuid, type = null) {
+  let path = `/assets/${uuid}/download`;
+  const req = this._requestParams("GET", path, {
+    qs: { type },
+    json: false,
+    encoding: null
+  });
+  return new Promise(function(resolve, reject) {
+    request(req, function(err, response, body) {
+      if (body) {
+        contentType = response.caseless.get("Content-Type");
+        if (contentType.indexOf("json") >= 0) {
+          try {
+            resolve(parseJSONResponse(body));
+          } catch (err) {
+            reject(err);
+          }
+        } else {
+          resolve(body);
+        }
+      } else {
+        reject(err);
+      }
+    });
+  });
+};
 
-Lingo.prototype._requestParams = function (method, path, more) {
-    let req = {
-        uri: 'https://api.lingoapp.com/alpha' + path,
-        method: method,
-        json: true,
-        headers: {},
-        ...more
-    }
-    req.headers.Authorization = this.auth
-    return req
-}
+Lingo.prototype._requestParams = function(method, path, more) {
+  let req = {
+    // uri: "https://api.lingoapp.com/alpha" + path,
+    uri: "https://api-test.lingoapp.com/alpha" + path,
+    method: method,
+    json: true,
+    headers: {},
+    ...more
+  };
+  req.headers.Authorization = this.auth;
+  return req;
+};
 
-Lingo.prototype.call = function (method, path, more = {}) {
-    const req = this._requestParams(method, path, more)
-    return new Promise(function (resolve, reject) {
-        request(req, function (err, response, body) {
-            if (body) {
-                try {
-                    resolve(parseJSONResponse(body))
-                } catch (err) {
-                    reject(err)
-                }
-            } else {
-                reject(err)
-            }
-        })
-    })
-}
+Lingo.prototype.call = function(method, path, more = {}) {
+  const req = this._requestParams(method, path, more);
+  return new Promise(function(resolve, reject) {
+    request(req, function(err, response, body) {
+      if (body) {
+        try {
+          resolve(parseJSONResponse(body));
+        } catch (err) {
+          reject(err);
+        }
+      } else {
+        reject(err);
+      }
+    });
+  });
+};
 
-
-
-module.exports = new Lingo()
-
+module.exports = new Lingo();

--- a/index.js
+++ b/index.js
@@ -88,12 +88,13 @@ Lingo.prototype.fetchSection = function(id, version, page = 1, limit = 50) {
 };
 
 /**
- * Fetch a section and optionally page through items with it
- * @param {uuid} id the section uuid
+ * Fetch all items that fall under a given heading in a section
+ * @param {uuid} sectionId the section uuid the heading is in
+ * @param {uuid|string} headingId the uuid or string name of the the heading
  * @param {integer} version the version number of the section to fetch
- * @param {integer} limit The max number of items to fetch
- * @param {integer} page the page of items
  * @returns {Promise} Success the section and the items matching the page/limit
+ *
+ * Note: If using the heading string, the first heading with that string will be used. UUID is recommended.
  */
 Lingo.prototype.fetchAssetsForHeading = function(
   sectionId,

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ Lingo.prototype.fetchKitOutline = function(id, version) {
  * @param {integer} version the version number of the section to fetch
  * @param {integer} limit The max number of items to fetch
  * @param {integer} page the page of items
- * @returns {Promise} Success the section and the items matching the page/limit
+ * @returns {Promise} A promise resolving the section and the items matching the page/limit
  */
 Lingo.prototype.fetchSection = function(id, version, page = 1, limit = 50) {
   let path = `/sections/${id}`;
@@ -92,7 +92,7 @@ Lingo.prototype.fetchSection = function(id, version, page = 1, limit = 50) {
  * @param {uuid} sectionId the section uuid the heading is in
  * @param {uuid|string} headingId the uuid or string name of the the heading
  * @param {integer} version the version number of the section to fetch
- * @returns {Promise} Success the section and the items matching the page/limit
+ * @returns {Promise} A promise resolving an array of items that fall under the desired heading. Can be empty.
  *
  * Note: If using the heading string, the first heading with that string will be used. UUID is recommended.
  */
@@ -108,8 +108,8 @@ Lingo.prototype.fetchAssetsForHeading = function(
 
     function isMatch(item) {
       return (
-        item.type == "heading" &&
-        (item.data.content == headingId || item.uuid == headingId)
+        item.type === "heading" &&
+        (item.data.content === headingId || item.uuid === headingId)
       );
     }
     const self = this;
@@ -194,8 +194,8 @@ Lingo.prototype.downloadAsset = function(uuid, type = null) {
 
 Lingo.prototype._requestParams = function(method, path, more) {
   let req = {
-    // uri: "https://api.lingoapp.com/alpha" + path,
-    uri: "https://api-test.lingoapp.com/alpha" + path,
+    uri: "https://api.lingoapp.com/alpha" + path,
+    // uri: "https://api-test.lingoapp.com/alpha" + path,
     method: method,
     json: true,
     headers: {},

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ assert(validConfig, "missing config attributes requires to run tests");
 it("Should fail to authenticate with invalid space", () => {
   lingo.setup(0, config.apiToken);
   return lingo.fetchKits().catch(err => {
-    assert(err.code == 401);
+    assert(err.code === 401);
     return Promise.resolve();
   });
 });
@@ -19,7 +19,7 @@ it("Should fail to authenticate with invalid space", () => {
 it("Should fail to authenticate with invalid api token", () => {
   lingo.setup(config.spaceID, "invalid-api-key");
   return lingo.fetchKits().catch(err => {
-    assert(err.code == 401);
+    assert(err.code === 401);
     return Promise.resolve();
   });
 });
@@ -54,7 +54,7 @@ it("Should fetch kit outline", () => {
 it("Should fetch section and items", () => {
   setup();
   return lingo.fetchSection(config.sectionID, 0).then(section => {
-    assert(section.uuid == config.sectionID, "expected sections");
+    assert(section.uuid === config.sectionID, "expected sections");
     assert(section.items.length > 0, "expected items");
   });
 });
@@ -65,7 +65,7 @@ it("Should fetch search results", () => {
     .searchAssetsInKit(config.kitID, 0, (query = "logo"))
     .then(results => {
       assert(results, "expected sections");
-      assert(results.query == "logo", "expected query to match");
+      assert(results.query === "logo", "expected query to match");
       assert(results.sections, "expected results");
     });
 });
@@ -82,7 +82,7 @@ it("Should fetch assets under header by id", () => {
   return lingo
     .fetchAssetsForHeading(config.sectionID, config.headingID, 0)
     .then(result => {
-      assert(result.length == 2, "Unexpected item count under heading");
+      assert(result.length === 2, "Unexpected item count under heading");
     });
 });
 
@@ -91,7 +91,7 @@ it("Should fetch assets under header by name", () => {
   return lingo
     .fetchAssetsForHeading(config.sectionID, config.headingName, 0)
     .then(result => {
-      assert(result.length == 2, "Unexpected item count under heading");
+      assert(result.length === 2, "Unexpected item count under heading");
       return result;
     });
 });

--- a/test.js
+++ b/test.js
@@ -1,70 +1,97 @@
-const lingo = require('./index')
-const assert = require('assert');
-const config = require('./test_config')
+const lingo = require("./index");
+const assert = require("assert");
+const config = require("./test_config");
 
 let validConfig = (config.spaceID,
-    config.apiToken,
-    config.kitID,
-    config.sectionID)
-assert(validConfig, 'missing config attributes requires to run tests')
+config.apiToken,
+config.kitID,
+config.sectionID);
+assert(validConfig, "missing config attributes requires to run tests");
 
+it("Should fail to authenticate with invalid space", () => {
+  lingo.setup(0, config.apiToken);
+  return lingo.fetchKits().catch(err => {
+    assert(err.code == 401);
+    return Promise.resolve();
+  });
+});
 
-lingo.setup(config.spaceID, config.apiToken)
+it("Should fail to authenticate with invalid api token", () => {
+  lingo.setup(config.spaceID, "invalid-api-key");
+  return lingo.fetchKits().catch(err => {
+    assert(err.code == 401);
+    return Promise.resolve();
+  });
+});
 
-it('Should fetch kits', function (done) {
-    lingo.fetchKits().then(res => {
-        assert(res.length, 'expected kits')
-        assert(res[0].kit_uuid, 'expected the kit to have a uuid')
-        done()
-    }).catch(err => {
-        done(err)
-    })
-})
+function setup() {
+  lingo.setup(config.spaceID, config.apiToken);
+}
 
-it('Should fetch kit with versions', function (done) {
-    lingo.fetchKit(config.kitID).then(kit => {
-        assert(kit.versions.length > 0, 'expected versions')
-        done()
-    }).catch(err => {
-        done(err)
-    })
-})
+it("Should fetch kits", () => {
+  setup();
+  lingo.setup(config.spaceID, config.apiToken);
+  return lingo.fetchKits().then(res => {
+    assert(res.length, "expected kits");
+    assert(res[0].kit_uuid, "expected the kit to have a uuid");
+  });
+});
 
-it('Should fetch kit outline', function (done) {
-    lingo.fetchKitOutline(config.kitID, 0).then(outline => {
-        assert(outline.length > 0, 'expected versions')
-        done()
-    }).catch(err => {
-        done(err)
-    })
-})
+it("Should fetch kit with versions", () => {
+  setup();
+  return lingo.fetchKit(config.kitID).then(kit => {
+    assert(kit.versions.length > 0, "expected versions");
+  });
+});
 
-it('Should fetch section and items', function (done) {
-    lingo.fetchSection(config.sectionID, 0).then(section => {
-        assert(section.uuid == config.sectionID, 'expected sections')
-        assert(section.items.length > 0, 'expected items')
-        done()
-    }).catch(err => {
-        done(err)
-    })
-})
+it("Should fetch kit outline", () => {
+  setup();
+  return lingo.fetchKitOutline(config.kitID, 0).then(outline => {
+    assert(outline.length > 0, "expected versions");
+  });
+});
 
-it('Should fetch search results', function (done) {
-    lingo.searchAssetsInKit(config.kitID, 0, query = 'logo').then(results => {
-        assert(results, 'expected sections')
-        assert(results.query == 'logo', 'expected query to match')
-        assert(results.sections, 'expected results')
-        done()
-    }).catch(err => {
-        done(err)
-    })
-})
+it("Should fetch section and items", () => {
+  setup();
+  return lingo.fetchSection(config.sectionID, 0).then(section => {
+    assert(section.uuid == config.sectionID, "expected sections");
+    assert(section.items.length > 0, "expected items");
+  });
+});
 
-it('Should download asset file', function (done) {
-    lingo.downloadAsset(config.assetID).then(result => {
-        assert(result instanceof Buffer, 'expected file buffer')
-        done()
-    }).catch(err => {
-        done(err)
-    })
-})
+it("Should fetch search results", () => {
+  setup();
+  return lingo
+    .searchAssetsInKit(config.kitID, 0, (query = "logo"))
+    .then(results => {
+      assert(results, "expected sections");
+      assert(results.query == "logo", "expected query to match");
+      assert(results.sections, "expected results");
+    });
+});
+
+it("Should download asset file", () => {
+  setup();
+  return lingo.downloadAsset(config.assetID).then(result => {
+    assert(result instanceof Buffer, "expected file buffer");
+  });
+});
+
+it("Should fetch assets under header by id", () => {
+  setup();
+  return lingo
+    .fetchAssetsForHeading(config.sectionID, config.headingID, 0)
+    .then(result => {
+      assert(result.length == 2, "Unexpected item count under heading");
+    });
+});
+
+it("Should fetch assets under header by name", () => {
+  setup();
+  return lingo
+    .fetchAssetsForHeading(config.sectionID, config.headingName, 0)
+    .then(result => {
+      assert(result.length == 2, "Unexpected item count under heading");
+      return result;
+    });
+});


### PR DESCRIPTION
Either of these will work although item ID is recommended. Using the heading name will always match the first heading with that string.
```javascript
lingo.fetchAssetsForHeading(<SectionID>, <HeadingUUID>, 0)
lingo.fetchAssetsForHeading(<SectionID>, <HeadingString>, 0)
```